### PR TITLE
New synoptic deadtime plots

### DIFF
--- a/PbStandardsAnalysis/TIMS_Pb_Standards_Setup_v1.m
+++ b/PbStandardsAnalysis/TIMS_Pb_Standards_Setup_v1.m
@@ -10,7 +10,7 @@ MSmethod.measMasses = {'204', '205', '206', '207', '208'};
 MSmethod.outRatios = {'204/206', '206/205', '207/206', '208/206'}; 
 MSmethod.cyclesPerBlock = 12; 
 MSmethod.BItimes = [10 2 1 2 3 2 5 2 3 2];
-MSmethod.BImethod = 'Quadrift'; %options: 'Dodson', 'Quadrift'
+MSmethod.BImethod = 'Dodson'; %options: 'Dodson', 'Quadrift'
 
 
 % Parse folder of Pb standard data files

--- a/PbStandardsAnalysis/brushPbStandardData_v1.m
+++ b/PbStandardsAnalysis/brushPbStandardData_v1.m
@@ -17,7 +17,7 @@ hPv = gobjects(n.runs,8); % graphics array of plot handles
 close(findall(0, 'Type', 'figure', 'Name', 'Raw Data'))
 uiparts.rawDataFigure = figure('Position', [100 100 1400 750], 'Name', 'Raw Data');
 
-tgroup = uitabgroup('Parent', uiparts.rawDataFigure);
+tgroup = uitabgroup('Parent', uiparts.rawDataFigure, 'TabLocation', 'top');
 tab = zeros(n.runs, 1);
 
 for irun = 1:n.runs
@@ -72,7 +72,6 @@ for irun = 1:n.runs
     runs(irun).hPv = hPv(irun,:);
 end
 
-session = [];
 close(findall(0, 'Type', 'figure', 'Name', 'Controls'))
 uiparts.ControlButton = figure('name', 'Controls', ...
                                 'WindowStyle', 'normal', 'Position', [50 50 200 200]);
@@ -85,6 +84,7 @@ uicontrol('Style', 'pushbutton', 'String', 'Synoptic Plots', ...
 
                              
 % keep uiparts in base workspace for other UI functions
+uiparts.rawDataTgroup = tgroup;
 assignin('base', 'uiparts', uiparts);
 
 

--- a/PbStandardsAnalysis/brushPbStandardData_v1.m
+++ b/PbStandardsAnalysis/brushPbStandardData_v1.m
@@ -72,13 +72,18 @@ for irun = 1:n.runs
     runs(irun).hPv = hPv(irun,:);
 end
 
+session = [];
 close(findall(0, 'Type', 'figure', 'Name', 'Controls'))
 uiparts.ControlButton = figure('name', 'Controls', ...
                                 'WindowStyle', 'normal', 'Position', [50 50 200 200]);
 uicontrol('Style', 'pushbutton', 'String', 'Reduce Data', ...
-                                 'Position', [10 10 100 20], ... 
+                                 'Position', [10 60 100 20], ... 
                                  'Callback', {@reduceBrushedPbData_v1, runs, MSmethod});
+uicontrol('Style', 'pushbutton', 'String', 'Synoptic Plots', ...
+                                 'Position', [10 10 100 20], ...
+                                 'Callback', {@synopticPlots});
 
+                             
 % keep uiparts in base workspace for other UI functions
 assignin('base', 'uiparts', uiparts);
 

--- a/PbStandardsAnalysis/parsePbStandardsPhoenix.m
+++ b/PbStandardsAnalysis/parsePbStandardsPhoenix.m
@@ -35,10 +35,10 @@ for i = 1:fileN
     runs(i).dt   = xlsread( [folderstring fileStruct(i).name], 'TUNING', 'J10' );
     %timestamp, converted to MATLAB's datenum:
     [~, runs(i).time] = xlsread( [folderstring fileStruct(i).name], 'CTRL', 'D22' );
-    runs(i).time = cell2mat(runs(i).time);
+    runs(i).time = cell2mat(runs(i).time); 
     temp.spaces = strfind(runs(i).time, ' ');
     runs(i).time = runs(i).time((temp.spaces(2)+1):end);
-    runs(i).time = datenum( runs(i).time );
+    runs(i).time = datenum( runs(i).time ) - 2000; % -2000 corrects Excel output for MATLAB datestr()
     %did this run do beam interpolation?:
     runs(i).bi   = xlsread( [folderstring fileStruct(i).name], 'CTRL', 'B46' );
     runs(i).standard = fileStruct(i).name(1:6); % NBS981 or NBS982?

--- a/PbStandardsAnalysis/synopticPlots.m
+++ b/PbStandardsAnalysis/synopticPlots.m
@@ -1,0 +1,36 @@
+function synopticPlots(obj, event_opj) %#ok<INUSD>
+session = evalin('base', 'session');
+runs = evalin('base', 'runs');
+uiparts = evalin('base', 'uiparts');
+
+n.runs = size(runs,1);
+
+close(findall(0, 'type', 'figure', 'name', 'Synoptic Plots'))
+
+uiparts.synopticFigure = figure('Position', [100 100 1400 750], 'Name', 'Synoptic Plots');
+tgroup = uitabgroup('Parent', uiparts.synopticFigure);
+tab = gobjects(2, 1);
+
+    tab(1) = uitab(tgroup, 'Title', 'Ratio vs. Intensity');
+    axes('parent', tab(1))
+
+for irun = 1:n.runs
+
+    switch runs(irun).standard
+        case 'NBS982', std = 1;
+        case 'NBS981', std = 2;
+    end
+    
+subplot(3,2,3-std); hold on
+plot(runs(irun).dataDT0(runs(irun).ratioStartCycles,3), runs(irun).BIdata(:,1), '.')
+
+subplot(3,2,5-std); hold on
+plot(runs(irun).dataDT0(runs(irun).ratioStartCycles,3), runs(irun).BIdata(:,3), '.')
+
+subplot(3,2,7-std); hold on
+plot(runs(irun).dataDT0(runs(irun).ratioStartCycles,3), runs(irun).BIdata(:,4), '.')
+
+end
+
+
+

--- a/PbStandardsAnalysis/synopticPlots.m
+++ b/PbStandardsAnalysis/synopticPlots.m
@@ -6,17 +6,19 @@ runs = evalin('base', 'runs');
 uiparts = evalin('base', 'uiparts');
 
 n.runs = size(runs,1);
-cmap = colormap('lines');
+cmap = colormap('lines'); % to distinguish data from different runs
 lwidth = 2; % line width for uncertainty bars
 
+% create uifigure and graphic objects structure for tabs
 close(findall(0, 'type', 'figure', 'name', 'Synoptic Plots'))
 uiparts.synopticFigure = figure('Position', [100 100 1400 750], 'Name', 'Synoptic Plots');
 tgroup = uitabgroup('Parent', uiparts.synopticFigure);
 tab = gobjects(3, 1); % 3 = ratio vs. intensity, fractionation vs. time, frac vs. temp.
 
-hPm = gobjects(n.runs, 6); % six for first uitab
-hAm = gobjects(n.runs, 6); % likewise
-
+% store handles for axes and plot data
+hPm = gobjects(n.runs, 4); % six for first uitab
+hAm = gobjects(3, 6); % likewise
+hLv = gobjects(n.runs,2); % for legend
 
 %% Ratio vs. intensity figure
 
@@ -31,6 +33,7 @@ axseph = 0.05;    % horizontal distance between plots
 axleft = 0.07;    % distance to left side of figure
 axbott = 0.09;    % distance to bottom of figure
 
+% place axes in position, first column is 981, second column is 982
 hAm(1,1) = axes('NextPlot', 'add', 'Parent', tab(1), 'Position', ... % 981 204/206
                 [axleft                axbott+2*axheight+2*axsepv axwidth axheight]);
 hAm(1,3) = axes('NextPlot', 'add', 'Parent', tab(1), 'Position', ... % 981 207/206
@@ -44,6 +47,7 @@ hAm(1,4) = axes('NextPlot', 'add', 'Parent', tab(1), 'Position', ... % 982 207/2
 hAm(1,6) = axes('NextPlot', 'add', 'Parent', tab(1), 'Position', ... % 982 208/206
                 [axleft+axwidth+axseph axbott                     axwidth axheight]);
 
+% labels, titles, and display properties
 set(hAm(1, [1 2 3 4]), 'XTickLabel', [])
 hAm(1,5).XLabel.String = 'Intensity (kcps)';
 hAm(1,6).XLabel.String = 'Intensity (kcps)';
@@ -73,7 +77,7 @@ title2.VerticalAlignment = 'middle';
 title2.LineStyle = 'none';
 set([title1 title2], 'FontSize', 20)
 
-
+% plot deadtime-uncorrected ratios vs. intensity for each run, intensity in kcps
 for irun = 1:n.runs
     
     switch runs(irun).standard
@@ -81,23 +85,37 @@ for irun = 1:n.runs
         case 'NBS981', std = 2;
     end
     
+hPm(irun, 1) = plot(runs(irun).dataDT0(runs(irun).ratioStartCycles,5)/1e3, ...
+    runs(irun).BIdata(:,1), '.', 'Parent', hAm(1, 3-std));
 
-plot(runs(irun).dataDT0(runs(irun).ratioStartCycles,5)/1e3, runs(irun).BIdata(:,1), ...
-    '.', 'Parent', hAm(1, 3-std))
+hPm(irun, 2) = plot(runs(irun).dataDT0(runs(irun).ratioStartCycles,5)/1e3, ...
+    runs(irun).BIdata(:,3), '.', 'Parent', hAm(1, 5-std));
 
-plot(runs(irun).dataDT0(runs(irun).ratioStartCycles,5)/1e3, runs(irun).BIdata(:,3), ... 
-    '.', 'Parent', hAm(1, 5-std))
-
-plot(runs(irun).dataDT0(runs(irun).ratioStartCycles,5)/1e3, runs(irun).BIdata(:,4), ...
-    '.', 'Parent', hAm(1, 7-std))
+hPm(irun, 3) = plot(runs(irun).dataDT0(runs(irun).ratioStartCycles,5)/1e3, ...
+    runs(irun).BIdata(:,4), '.', 'Parent', hAm(1, 7-std));
 
 end
+
+% create large markers for legend entries in hLv, hidden behind legend
+axes('Position', [0.85 0.5 0.01 0.01], 'Parent', tab(1))
+hold on
+for irun = 1:n.runs
+    hLv(irun, 1) = plot(0, 0, '.', 'MarkerSize', 20, 'Color', cmap(irun,:));
+end
+
+% create legend, position at right of figure
+pos = [(axleft + 2*axwidth + 2*axseph) axbott ...
+            (1 - axleft - 2*axwidth - 3*axseph) (3*axheight+2*axsepv)]; %legend position
+lgd1 = legend(hLv(:,1), {runs(:).name});
+set(lgd1, 'Position', pos, 'Units', 'normalized', 'FontSize', 12)
 
 
 %% Fractionation vs. temperature
 
+
 tab(2) = uitab(tgroup, 'Title', 'Fractionation vs. Temp');
-hAm(2,1) = axes('parent', tab(2));
+hAm(2,1) = axes('parent', tab(2), 'Position', ...
+        [axleft axbott, 2*axwidth+axseph, (1-axbott-0.01)]);
 
 hold on
 for irun = 1:n.runs
@@ -107,7 +125,7 @@ for irun = 1:n.runs
         case 'NBS982', markerstr = 'o';
     end
     
-    hPm(2, irun) = scatter(runs(irun).temp(runs(irun).ratioStartCycles), ...
+    hPm(irun, 4) = scatter(runs(irun).temp(runs(irun).ratioStartCycles), ...
         runs(irun).beta(:,3), 100, 'Marker', markerstr, ...
         'MarkerFaceColor', cmap(irun,:), 'MarkerEdgeColor', 'k', ...
         'MarkerFaceAlpha', 0.7);
@@ -119,6 +137,28 @@ xlim([1050 xl(2)]) % 1050 is minimum realistic temperature
 xlabel('Temperature (C)', 'FontSize', 20)
 ylabel('\beta (208Pb/206Pb)', 'FontSize', 20)
 
+
+% create large markers for legend entries in hLv, hidden behind legend
+axes('Position', [0.85 0.5 0.01 0.01], 'Parent', tab(2))
+hold on
+for irun = 1:n.runs
+    
+    switch runs(irun).standard
+        case 'NBS981', markerstr = 's';
+        case 'NBS982', markerstr = 'o';
+    end
+    
+    hLv(irun, 2) = scatter(0, 0, 600, 'Marker', markerstr, ...
+        'MarkerFaceColor', cmap(irun,:), 'MarkerEdgeColor', 'k', ...
+        'MarkerFaceAlpha', 0.7);
+end
+
+% make legend
+warning('off', 'MATLAB:handle_graphics:exceptions:SceneNode'); % remove tab-related warning
+[lgd2, hobj2, ~, ~] = legend(hLv(:,2), {runs(:).name});
+set(lgd2, 'Position', [pos(1)-0.04 pos(2) 0.15 pos(4)], 'Units', 'normalized', 'FontSize', 12)
+set(findobj(hobj2,'type','patch'), 'MarkerSize',10, 'FaceAlpha', 0.7)
+set(findobj(hobj2,'type','Text') , 'FontSize', 12)
 
 %% Fractionation vs. time
 


### PR DESCRIPTION
Added synoptic data plots for entire session.  Should be useful for viewing time-dependent instrument parameters.  Can add more statistical visualizations (e.g. run vs. chi-square contribution) in future.